### PR TITLE
linkfix to DNSSEC test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Testing your domain:
 - <http://dnssec-debugger.verisignlabs.com/>
 - <http://dnsviz.net/>
 - <http://www.dnssy.com/>
-- <http://dnssec.vs.uni-due.de/>
+- <https://wander.science/projects/dns/dnssec-resolver-test/>
 
 ## License
 


### PR DESCRIPTION
dnssec.vs.uni-due.de is down, but I've relaunched the service on https://wander.science/projects/dns/dnssec-resolver-test/